### PR TITLE
Use util.inherits to inherit EventEmitter prototype

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,9 @@
+"use strict";
+
 var stream       = require("stream");
 var EventEmitter = require("events").EventEmitter;
 var _            = require("UnderscoreKit")._;
+var inherits     = require("util").inherits;
 
 var _eventProxy = function(message) {
     // not an ipc stream conainer? then ignore this message
@@ -33,7 +36,7 @@ var Channel = function(channel, name) {
     this._channel.on("message", _.bind(_eventProxy, this));
 };
 
-Channel.prototype = EventEmitter.prototype;
+inherits(Channel, EventEmitter);
 
 Channel.prototype.message = function(type, data) {
     return {ipc_n: this._name, ipc_t: type, ipc_d: data};


### PR DESCRIPTION
I ran into a random bug where some other module's prototype was funky because this module ultimately modified the EventEmitter prototype. Using the inherits function provided in the util module fixed the issue for me.